### PR TITLE
Displays specific number of resources required

### DIFF
--- a/src/main/java/thestonedturtle/mahoganyhomes/Home.java
+++ b/src/main/java/thestonedturtle/mahoganyhomes/Home.java
@@ -31,41 +31,43 @@ import net.runelite.api.coords.WorldArea;
 import net.runelite.api.coords.WorldPoint;
 import org.apache.commons.text.WordUtils;
 
+import java.util.Set;
+
 @Getter
 enum Home
 {
 	// area is based on bounds of house not area at which stuff loads in for the homes
 	// Ardy
 	JESS(new WorldArea(2611, 3290, 14, 7, 0), "Upstairs of the building south of the church in East Ardougne",
-		NpcID.JESS, new WorldPoint(2621, 3292, 0), RequiredMaterialsByTier.JESS, 17026, 16685),
+		NpcID.JESS, new WorldPoint(2621, 3292, 0), RequiredMaterialsByTier.JESS, HomeHotspot.JESS, 17026, 16685),
 	NOELLA(new WorldArea(2652, 3317, 15, 8, 0), "North of East Ardougne market",
-		NpcID.NOELLA, new WorldPoint(2659, 3322, 0), RequiredMaterialsByTier.NOELLA, 17026, 16685, 15645, 15648),
+		NpcID.NOELLA, new WorldPoint(2659, 3322, 0), RequiredMaterialsByTier.NOELLA, HomeHotspot.NOELLA, 17026, 16685, 15645, 15648),
 	ROSS(new WorldArea(2609, 3313, 11, 9, 0), "North of the church in East Ardougne",
-		NpcID.ROSS, new WorldPoint(2613, 3316, 0), RequiredMaterialsByTier.ROSS, 16683, 16679),
+		NpcID.ROSS, new WorldPoint(2613, 3316, 0), RequiredMaterialsByTier.ROSS, HomeHotspot.ROSS, 16683, 16679),
 
 	// Falador
 	LARRY(new WorldArea(3033, 3360, 10, 9, 0), "North of the fountain in Falador",
-		NpcID.LARRY_10418, new WorldPoint(3038, 3364, 0), RequiredMaterialsByTier.LARRY, 24075, 24076),
+		NpcID.LARRY_10418, new WorldPoint(3038, 3364, 0), RequiredMaterialsByTier.LARRY, HomeHotspot.LARRY, 24075, 24076),
 	NORMAN(new WorldArea(3034, 3341, 8, 8, 0), "South of the fountain in Falador",
-		NpcID.NORMAN, new WorldPoint(3038, 3344, 0), RequiredMaterialsByTier.NORMAN, 24082, 24085),
+		NpcID.NORMAN, new WorldPoint(3038, 3344, 0), RequiredMaterialsByTier.NORMAN, HomeHotspot.NORMAN, 24082, 24085),
 	TAU(new WorldArea(3043, 3340, 10, 11, 0), "South east of the fountain in Falador",
-		NpcID.TAU, new WorldPoint(3047, 3345, 0), RequiredMaterialsByTier.TAU),
+		NpcID.TAU, new WorldPoint(3047, 3345, 0), RequiredMaterialsByTier.TAU, HomeHotspot.TAU),
 
 	// Hosidus
 	BARBARA(new WorldArea(1746, 3531, 10, 11, 0), "South of Hosidius, near the mill",
-		NpcID.BARBARA, new WorldPoint(1750, 3534, 0), RequiredMaterialsByTier.BARBARA),
+		NpcID.BARBARA, new WorldPoint(1750, 3534, 0), RequiredMaterialsByTier.BARBARA, HomeHotspot.BARBARA),
 	LEELA(new WorldArea(1781, 3589, 9, 8, 0), "East of the town market in Hosidius",
-		NpcID.LEELA_10423, new WorldPoint(1785, 3592, 0), RequiredMaterialsByTier.LEELA, 11794, 11802),
+		NpcID.LEELA_10423, new WorldPoint(1785, 3592, 0), RequiredMaterialsByTier.LEELA, HomeHotspot.LEELA, 11794, 11802),
 	MARIAH(new WorldArea(1762, 3618, 10, 7, 0), "West of the estate agents in Hosidius",
-		NpcID.MARIAH, new WorldPoint(1766, 3621, 0), RequiredMaterialsByTier.MARIAH, 11794, 11802),
+		NpcID.MARIAH, new WorldPoint(1766, 3621, 0), RequiredMaterialsByTier.MARIAH, HomeHotspot.MARIAH, 11794, 11802),
 
 	// Varrock
 	BOB(new WorldArea(3234, 3482, 10, 10, 0), "North-east Varrock, opposite the church",
-		NpcID.BOB_10414, new WorldPoint(3238, 3486, 0), RequiredMaterialsByTier.BOB, 11797, 11799),
+		NpcID.BOB_10414, new WorldPoint(3238, 3486, 0), RequiredMaterialsByTier.BOB, HomeHotspot.BOB, 11797, 11799),
 	JEFF(new WorldArea(3235, 3445, 10, 12, 0), "Middle of Varrock, west of the museum",
-		NpcID.JEFF_10415, new WorldPoint(3239, 3450, 0), RequiredMaterialsByTier.JEFF, 11789, 11793),
+		NpcID.JEFF_10415, new WorldPoint(3239, 3450, 0), RequiredMaterialsByTier.JEFF, HomeHotspot.JEFF, 11789, 11793),
 	SARAH(new WorldArea(3232, 3381, 8, 7, 0), "Along the south wall of Varrock",
-		NpcID.SARAH_10416, new WorldPoint(3235, 3384, 0), RequiredMaterialsByTier.SARAH);
+		NpcID.SARAH_10416, new WorldPoint(3235, 3384, 0), RequiredMaterialsByTier.SARAH, HomeHotspot.SARAH);
 
 	private final WorldArea area;
 	private final String hint;
@@ -74,7 +76,9 @@ enum Home
 	private final Integer[] ladders;
 	private final RequiredMaterialsByTier requiredMaterialsByTier;
 
-	Home(final WorldArea area, final String hint, final int npcId, final WorldPoint location, final RequiredMaterialsByTier requiredMaterials, final Integer... ladders)
+	private final HomeHotspot homeHotspot;
+
+	Home(final WorldArea area, final String hint, final int npcId, final WorldPoint location, final RequiredMaterialsByTier requiredMaterials, final HomeHotspot homeHotspot, final Integer... ladders)
 	{
 		this.area = area;
 		this.hint = hint;
@@ -82,6 +86,7 @@ enum Home
 		this.location = location;
 		this.ladders = ladders;
 		this.requiredMaterialsByTier = requiredMaterials;
+		this.homeHotspot = homeHotspot;
 	}
 
 	String getName()
@@ -89,9 +94,7 @@ enum Home
 		return WordUtils.capitalize(name().toLowerCase());
 	}
 
-	String getRequiredPlanks(int tier)
-	{
-		RequiredMaterials requiredMaterials = this.requiredMaterialsByTier.getByTier(tier);
+	private String plankInStringFormat(RequiredMaterials requiredMaterials){
 		if (requiredMaterials == null)
 		{
 			return null;
@@ -105,9 +108,23 @@ enum Home
 		return String.format("%d - %d planks", requiredMaterials.MinPlanks, requiredMaterials.MaxPlanks);
 	}
 
-	String getRequiredSteelBars(int tier)
+	String getRequiredPlanks(int tier)
 	{
 		RequiredMaterials requiredMaterials = this.requiredMaterialsByTier.getByTier(tier);
+		return plankInStringFormat(requiredMaterials);
+	}
+
+	String getRequiredPlanks(Set<Integer> repairableVarbits)
+	{
+		RequiredMaterials requiredMaterials = null;
+		if (repairableVarbits != null && repairableVarbits.size() > 0){
+			requiredMaterials = homeHotspot.getRequiredMaterials(repairableVarbits);
+		}
+
+		return plankInStringFormat(requiredMaterials);
+	}
+
+	private String steelbarsInStringFormat(RequiredMaterials requiredMaterials){
 		if (requiredMaterials == null)
 		{
 			return null;
@@ -124,6 +141,22 @@ enum Home
 		}
 
 		return String.format("%d - %d steel bars", requiredMaterials.MinSteelBars, requiredMaterials.MaxSteelBars);
+	}
+
+	String getRequiredSteelBars(int tier)
+	{
+		RequiredMaterials requiredMaterials = this.requiredMaterialsByTier.getByTier(tier);
+		return steelbarsInStringFormat(requiredMaterials);
+	}
+
+	String getRequiredSteelBars(Set<Integer> repairableVarbits)
+	{
+		RequiredMaterials requiredMaterials = null;
+		if (repairableVarbits != null && repairableVarbits.size() > 0){
+			requiredMaterials = homeHotspot.getRequiredMaterials(repairableVarbits);
+		}
+
+		return steelbarsInStringFormat(requiredMaterials);
 	}
 
 	private static final ImmutableSet<Integer> LADDERS;

--- a/src/main/java/thestonedturtle/mahoganyhomes/HomeHotspot.java
+++ b/src/main/java/thestonedturtle/mahoganyhomes/HomeHotspot.java
@@ -1,0 +1,147 @@
+package thestonedturtle.mahoganyhomes;
+
+import com.google.common.collect.ImmutableMap;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.Set;
+
+import static thestonedturtle.mahoganyhomes.HotspotType.*;
+
+public enum HomeHotspot {
+
+	// East Ardy
+	JESS(new ObjectHotspot(40171, B2),
+			new ObjectHotspot(40172, B2),
+			new ObjectHotspot(40173, B2),
+			new ObjectHotspot(40174, B2),
+			new ObjectHotspot(40175, B3),
+			new ObjectHotspot(40176, B3),
+			new ObjectHotspot(40177, RP),
+			new ObjectHotspot(40299, SB)),
+	NOELLA(new ObjectHotspot(40156, B2),
+			new ObjectHotspot(40157, B2),
+			new ObjectHotspot(40158, RP),
+			new ObjectHotspot(40159, RP),
+			new ObjectHotspot(40160, B2),
+			new ObjectHotspot(40161, B3),
+			new ObjectHotspot(40162, B3),
+			new ObjectHotspot(40163, RP)),
+	ROSS(new ObjectHotspot(40164, SB),
+			new ObjectHotspot(40165, B2),
+			new ObjectHotspot(40166, B2),
+			new ObjectHotspot(40167, B3),
+			new ObjectHotspot(40168, RP),
+			new ObjectHotspot(40169, B2),
+			new ObjectHotspot(40170, RP)),
+
+	// Falador
+	LARRY(new ObjectHotspot(40297, SB),
+			new ObjectHotspot(40095, B2),
+			new ObjectHotspot(40096, B2),
+			new ObjectHotspot(40097, B3),
+			new ObjectHotspot(40298, RP),
+			new ObjectHotspot(40098, B3),
+			new ObjectHotspot(40099, RP)),
+	NORMAN(new ObjectHotspot(40296, SB),
+			new ObjectHotspot(40089, RP),
+			new ObjectHotspot(40090, B3),
+			new ObjectHotspot(40091, B3),
+			new ObjectHotspot(40092, B2),
+			new ObjectHotspot(40093, B2),
+			new ObjectHotspot(40094, B2)),
+	TAU(new ObjectHotspot(40083, SB),
+			new ObjectHotspot(40084, B3),
+			new ObjectHotspot(40085, B3),
+			new ObjectHotspot(40086, B2),
+			new ObjectHotspot(40087, B2),
+			new ObjectHotspot(40088, B2),
+			new ObjectHotspot(40295, RP)),
+
+	// Hosidius
+	BARBARA(new ObjectHotspot(40011, RP),
+			new ObjectHotspot(40293, SB),
+			new ObjectHotspot(40012, B3),
+			new ObjectHotspot(40294, B2),
+			new ObjectHotspot(40013, B2),
+			new ObjectHotspot(40014, B1),
+			new ObjectHotspot(40015, B1)),
+	LEELA(new ObjectHotspot(40007, B2),
+			new ObjectHotspot(40008, B2),
+			new ObjectHotspot(40290, SB),
+			new ObjectHotspot(40291, B3),
+			new ObjectHotspot(40009, B3),
+			new ObjectHotspot(40010, RP),
+			new ObjectHotspot(40292, B2)),
+	MARIAH(new ObjectHotspot(40002, B3),
+			new ObjectHotspot(40287, SB),
+			new ObjectHotspot(40003, B2),
+			new ObjectHotspot(40288, B2),
+			new ObjectHotspot(40004, B2),
+			new ObjectHotspot(40005, B2),
+			new ObjectHotspot(40006, B2),
+			new ObjectHotspot(40289, RP)),
+
+
+	// Varrock
+	BOB(new ObjectHotspot(39981, B4),
+			new ObjectHotspot(39982, RP),
+			new ObjectHotspot(39983, B2),
+			new ObjectHotspot(39984, B2),
+			new ObjectHotspot(39985, B2),
+			new ObjectHotspot(39986, B2),
+			new ObjectHotspot(39987, B2),
+			new ObjectHotspot(39988, B2)),
+	JEFF(new ObjectHotspot(39989, B3),
+			new ObjectHotspot(39990, B2),
+			new ObjectHotspot(39991, B2),
+			new ObjectHotspot(39992, B3),
+			new ObjectHotspot(39993, B2),
+			new ObjectHotspot(39994, B2),
+			new ObjectHotspot(39995, RP),
+			new ObjectHotspot(39996, B1)),
+	SARAH(new ObjectHotspot(39997, B3),
+			new ObjectHotspot(39998, B2),
+			new ObjectHotspot(39999, B2),
+			new ObjectHotspot(40000, B2),
+			new ObjectHotspot(40286, SB),
+			new ObjectHotspot(40001, B2));
+
+
+	@AllArgsConstructor
+	@Getter
+	private static class ObjectHotspot {
+		int objectId;
+		HotspotType hotspotType;
+	}
+
+	final ImmutableMap<Integer, ObjectHotspot> varBitToObjectHotspotMap;
+
+	HomeHotspot(ObjectHotspot... objectHotspots) {
+		final ImmutableMap.Builder<Integer, ObjectHotspot> objects = new ImmutableMap.Builder<>();
+		int varBit = 10554;
+		for (final ObjectHotspot objectHotspot : objectHotspots) {
+			objects.put(varBit++, objectHotspot);
+		}
+		varBitToObjectHotspotMap = objects.build();
+	}
+
+	public ObjectHotspot getObjectHotspot(int varbit) {
+		return varBitToObjectHotspotMap.get(varbit);
+	}
+
+	public RequiredMaterials getRequiredMaterials(Set<Integer> varbits) {
+		int numOfPlanks = 0;
+		int numOfSteelBars = 0;
+		for (int varbit : varbits) {
+			ObjectHotspot objectHotspot = getObjectHotspot(varbit);
+			if (objectHotspot == null) return null;
+			Material material = objectHotspot.getHotspotType().getMaterial();
+			int numOfMaterial = objectHotspot.getHotspotType().getNumOfMaterial();
+			if (Material.PLANK.equals(material)) numOfPlanks += numOfMaterial;
+			else if (Material.STEEL_BAR.equals(material)) numOfSteelBars += numOfMaterial;
+		}
+		return new RequiredMaterials(numOfPlanks, numOfPlanks, numOfSteelBars, numOfSteelBars);
+	}
+
+}

--- a/src/main/java/thestonedturtle/mahoganyhomes/HotspotType.java
+++ b/src/main/java/thestonedturtle/mahoganyhomes/HotspotType.java
@@ -1,0 +1,29 @@
+package thestonedturtle.mahoganyhomes;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import static thestonedturtle.mahoganyhomes.Material.PLANK;
+import static thestonedturtle.mahoganyhomes.Material.STEEL_BAR;
+
+@AllArgsConstructor
+@Getter
+public enum HotspotType {
+
+	//Remove & Build Furniture (1 plank)
+	B1(PLANK, 1),
+	//Remove & Build Furniture (2 plank)
+	B2(PLANK, 2),
+	//Remove & Build Furniture (3 plank)
+	B3(PLANK, 3),
+	//Remove & Build Furniture (4 plank)
+	B4(PLANK, 4),
+	//Repair Furniture (1 plank)
+	RP(PLANK, 1),
+	//Repair Furniture (1 steel bar)
+	SB(STEEL_BAR, 1);
+
+	private final Material material;
+	private final int numOfMaterial;
+
+}

--- a/src/main/java/thestonedturtle/mahoganyhomes/MahoganyHomesOverlay.java
+++ b/src/main/java/thestonedturtle/mahoganyhomes/MahoganyHomesOverlay.java
@@ -80,20 +80,20 @@ class MahoganyHomesOverlay extends OverlayPanel
 			addLine(home.getName());
 			addLine(home.getHint());
 
-			if (config.showRequiredMaterials() && plugin.getContractTier() > 0)
-			{
-				addLine("");
-				addLine(home.getRequiredPlanks(plugin.getContractTier()));
-
-				String bars = home.getRequiredSteelBars(plugin.getContractTier());
-				if (bars != null)
-				{
-					addLine(bars);
-				}
-			}
-
 			if (plugin.distanceBetween(home.getArea(), player.getWorldLocation()) > 0)
 			{
+				if (config.showRequiredMaterials() && plugin.getContractTier() > 0)
+				{
+					addLine("");
+					addLine(home.getRequiredPlanks(plugin.getContractTier()));
+
+					String bars = home.getRequiredSteelBars(plugin.getContractTier());
+					if (bars != null)
+					{
+						addLine(bars);
+					}
+				}
+
 				if (config.worldMapIcon())
 				{
 					addLine("");
@@ -106,6 +106,20 @@ class MahoganyHomesOverlay extends OverlayPanel
 				final int count = plugin.getCompletedCount();
 				if (count > 0)
 				{
+
+					if (config.showRequiredMaterials() && plugin.getContractTier() > 0)
+					{
+
+						addLine(home.getRequiredPlanks(plugin.getRepairableVarbs()));
+
+						String bars = home.getRequiredSteelBars(plugin.getRepairableVarbs());
+						if (bars != null)
+						{
+							addLine(bars);
+						}
+					}
+
+					addLine("");
 					panelComponent.getChildren().add(LineComponent.builder()
 						.left(count + " task(s) remaining")
 						.leftColor(Color.RED)

--- a/src/main/java/thestonedturtle/mahoganyhomes/MahoganyHomesPlugin.java
+++ b/src/main/java/thestonedturtle/mahoganyhomes/MahoganyHomesPlugin.java
@@ -5,10 +5,7 @@ import com.google.inject.Provides;
 import java.awt.image.BufferedImage;
 import java.time.Duration;
 import java.time.Instant;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import javax.inject.Inject;
@@ -430,6 +427,17 @@ public class MahoganyHomesPlugin extends Plugin
 		{
 			varbMap.put(spot.getVarb(), client.getVarbitValue(spot.getVarb()));
 		}
+	}
+
+	public Set<Integer> getRepairableVarbs(){
+		Collection<Integer> varbs = varbMap.keySet();
+
+		Set<Integer> repairableVarbs = new HashSet<>();
+
+		for (Integer varb : varbs){
+			if (doesHotspotRequireAttention(varb)) repairableVarbs.add(varb);
+		}
+		return repairableVarbs;
 	}
 
 	private void loadFromConfig()

--- a/src/main/java/thestonedturtle/mahoganyhomes/Material.java
+++ b/src/main/java/thestonedturtle/mahoganyhomes/Material.java
@@ -1,0 +1,6 @@
+package thestonedturtle.mahoganyhomes;
+
+public enum Material {
+	PLANK,
+	STEEL_BAR
+}


### PR DESCRIPTION
Added functionality that calculates the number of resource required once you are close enough to the home. It will also continuously update resources required as you build. 

For example, when I am too far away from my assigned home, I still get resources required displayed as a range (existing functionality)
![image](https://user-images.githubusercontent.com/11383662/216840883-04533440-d843-4532-8e6d-8744603aabe0.png)


Once I am close to my home, it now displays the specific number of resources required (new functionality)
![image](https://user-images.githubusercontent.com/11383662/216840965-1dff0826-4a91-4c7c-b72c-9b2a3e5b7f17.png)

As I build objects, the number of resource required will continuously get updated. (new functionality)
![image](https://user-images.githubusercontent.com/11383662/216841204-8e9bd26d-66b5-4c84-a294-fc8aa31e72ec.png)


Once everything is built, we completely remove the resources required from displaying (new functionality)
![image](https://user-images.githubusercontent.com/11383662/216841036-12d42592-7928-4e54-be07-00a549fcaa21.png)

Also it is possible to remove Hotspot class file by doing a few refactoring and moving some functionality to HomeHotspot class file. I decided against that to minimize the amount of code changes. Lmk if this is something you want me to do however.

Edit: Forgot to mention, I cross-verified the varbit-objectid relation defined in HomeHotspot class with Hotspot class to ensure there weren't any mistakes.