### PR TITLE
Add support for new plank sack varbits

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,8 +16,8 @@ def runeLiteVersion = 'latest.release'
 dependencies {
 	compileOnly group: 'net.runelite', name:'client', version: runeLiteVersion
 
-	compileOnly 'org.projectlombok:lombok:1.18.4'
-	annotationProcessor 'org.projectlombok:lombok:1.18.4'
+	compileOnly 'org.projectlombok:lombok:1.18.42'
+	annotationProcessor 'org.projectlombok:lombok:1.18.42'
 
     testImplementation group: 'org.mockito', name: 'mockito-core', version: '3.5.7'
 	testImplementation 'junit:junit:4.12'

--- a/src/main/java/thestonedturtle/mahoganyhomes/MahoganyHomesConfig.java
+++ b/src/main/java/thestonedturtle/mahoganyhomes/MahoganyHomesConfig.java
@@ -225,7 +225,7 @@ public interface MahoganyHomesConfig extends Config
 		keyName = "checkSupplies",
 		name = "Check Supplies",
 		description = "Checks if you have enough supplies in your inventory to complete your current contract.<br/>" +
-			"If the Plank Sack plugin is installed, it will include all planks within the plank sack regardless of plank type",
+            "If the plank sack is in your inventory, this will include planks of the correct type that are stored within it.",
 		position = 10
 	)
 	default boolean checkSupplies()


### PR DESCRIPTION
This removes the dependence on the plank sack plugin (which no longer uses those configs anyway) and implements reading the plank sack values directly, now that with the post-sailing changes they are available as varbits. As such it specifically reads the contract plank type too, rather than just the contents as a whole.

Also had to bump lombok's version up to get it to run and compile on later java versions (including the one I happened to have in use)

Let me know if there's any issues or concerns!

(note, the new revision of the plank sack plugin is used to reference the contents in the screenshot)
<img width="1503" height="897" alt="image" src="https://github.com/user-attachments/assets/c10f79e6-53e8-46a3-aa69-605b33f1e151" />
